### PR TITLE
Allow to work with latest yard-0.9.6 and yard-api-1.0.1

### DIFF
--- a/templates/api/layout/html/setup.rb
+++ b/templates/api/layout/html/setup.rb
@@ -1,5 +1,5 @@
 def stylesheets
-  theme = case api_options.theme
+  theme = case api_options.theme.downcase
   when 'vroom'
     'css/vroom.css'
   when 'default', 'slate', 'slatelike'

--- a/yard-api-slatelike.gemspec
+++ b/yard-api-slatelike.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |s|
                   ['LICENSE', 'README.md', '.rspec', __FILE__]
   s.has_rdoc    = 'yard'
   s.license     = 'AGPL3'
-  s.add_dependency 'yard', '0.8.7'
-  s.add_dependency 'yard-api'
+  s.add_dependency 'yard', '>=0.8.7', '<1.0.0'
+  s.add_dependency 'yard-api', '>=0.1.2', '<2.0.0'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'gem-release'
 end


### PR DESCRIPTION
Adding case-insensitive theme-name identification (because `yard_api.yml` of `yard-api` now sets the default template to `Default`) and improving the GEMspec requirement specifications allows the gem to work also with the latest `yard` and `yard-api` gems.